### PR TITLE
Refactor search endpoints to use strategy pattern

### DIFF
--- a/src/main/java/com/example/restate/service/search/AdvancedSearchStrategy.java
+++ b/src/main/java/com/example/restate/service/search/AdvancedSearchStrategy.java
@@ -1,0 +1,98 @@
+package com.example.restate.service.search;
+
+import com.example.restate.dto.MieszkanieSearchCriteria;
+import com.example.restate.dto.PageResponse;
+import com.example.restate.entity.Mieszkanie;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Zaawansowana strategia wyszukiwania - wiele kryteriów
+ */
+@Component
+@RequiredArgsConstructor
+public class AdvancedSearchStrategy implements SearchStrategy {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public PageResponse<Mieszkanie> search(MieszkanieSearchCriteria criteria, Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Mieszkanie> query = cb.createQuery(Mieszkanie.class);
+        Root<Mieszkanie> mieszkanie = query.from(Mieszkanie.class);
+
+        List<Predicate> predicates = buildPredicates(cb, mieszkanie, criteria);
+        query.where(predicates.toArray(new Predicate[0]));
+
+        // Count query
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<Mieszkanie> countRoot = countQuery.from(Mieszkanie.class);
+        countQuery.select(cb.count(countRoot));
+        countQuery.where(predicates.toArray(new Predicate[0]));
+        Long totalElements = entityManager.createQuery(countQuery).getSingleResult();
+
+        // Apply pagination
+        TypedQuery<Mieszkanie> typedQuery = entityManager.createQuery(query);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<Mieszkanie> content = typedQuery.getResultList();
+        Page<Mieszkanie> page = new PageImpl<>(content, pageable, totalElements);
+
+        return convertToPageResponse(page);
+    }
+
+    @Override
+    public boolean supports(SearchType searchType) {
+        return SearchType.ADVANCED.equals(searchType);
+    }
+
+    private List<Predicate> buildPredicates(CriteriaBuilder cb, Root<Mieszkanie> root,
+                                            MieszkanieSearchCriteria criteria) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (criteria.getDeveloper() != null) {
+            predicates.add(cb.equal(root.get("developer"), criteria.getDeveloper()));
+        }
+
+        if (criteria.getMinPrice() != null && criteria.getMaxPrice() != null) {
+            predicates.add(cb.between(root.get("price"),
+                    criteria.getMinPrice(), criteria.getMaxPrice()));
+        }
+
+        if (criteria.getMinArea() != null && criteria.getMaxArea() != null) {
+            predicates.add(cb.between(root.get("area"),
+                    criteria.getMinArea(), criteria.getMaxArea()));
+        }
+
+        if (criteria.getCity() != null) {
+            predicates.add(cb.equal(root.get("city"), criteria.getCity()));
+        }
+
+        return predicates;
+    }
+
+    private PageResponse<Mieszkanie> convertToPageResponse(Page<Mieszkanie> page) {
+        return PageResponse.<Mieszkanie>builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .first(page.isFirst())
+                .build();
+    }
+}

--- a/src/main/java/com/example/restate/service/search/LocationSearchStrategy.java
+++ b/src/main/java/com/example/restate/service/search/LocationSearchStrategy.java
@@ -1,0 +1,85 @@
+package com.example.restate.service.search;
+
+import com.example.restate.dto.MieszkanieSearchCriteria;
+import com.example.restate.dto.PageResponse;
+import com.example.restate.entity.Mieszkanie;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Strategia wyszukiwania po lokalizacji
+ */
+@Component
+@RequiredArgsConstructor
+public class LocationSearchStrategy implements SearchStrategy {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public PageResponse<Mieszkanie> search(MieszkanieSearchCriteria criteria, Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Mieszkanie> query = cb.createQuery(Mieszkanie.class);
+        Root<Mieszkanie> mieszkanie = query.from(Mieszkanie.class);
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (criteria.getVoivodeship() != null) {
+            predicates.add(cb.equal(mieszkanie.get("voivodeship"), criteria.getVoivodeship()));
+        }
+        if (criteria.getCity() != null) {
+            predicates.add(cb.equal(mieszkanie.get("city"), criteria.getCity()));
+        }
+        if (criteria.getDistrict() != null) {
+            predicates.add(cb.equal(mieszkanie.get("district"), criteria.getDistrict()));
+        }
+
+        query.where(predicates.toArray(new Predicate[0]));
+
+        TypedQuery<Mieszkanie> typedQuery = entityManager.createQuery(query);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<Mieszkanie> content = typedQuery.getResultList();
+        long totalElements = getTotalCount(cb, predicates);
+
+        Page<Mieszkanie> page = new PageImpl<>(content, pageable, totalElements);
+        return convertToPageResponse(page);
+    }
+
+    @Override
+    public boolean supports(SearchType searchType) {
+        return SearchType.BY_LOCATION.equals(searchType);
+    }
+
+    private long getTotalCount(CriteriaBuilder cb, List<Predicate> predicates) {
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<Mieszkanie> countRoot = countQuery.from(Mieszkanie.class);
+        countQuery.select(cb.count(countRoot));
+        countQuery.where(predicates.toArray(new Predicate[0]));
+        return entityManager.createQuery(countQuery).getSingleResult();
+    }
+
+    private PageResponse<Mieszkanie> convertToPageResponse(Page<Mieszkanie> page) {
+        return PageResponse.<Mieszkanie>builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .first(page.isFirst())
+                .build();
+    }
+}

--- a/src/main/java/com/example/restate/service/search/SearchContext.java
+++ b/src/main/java/com/example/restate/service/search/SearchContext.java
@@ -1,0 +1,56 @@
+package com.example.restate.service.search;
+
+import com.example.restate.dto.MieszkanieSearchCriteria;
+import com.example.restate.dto.PageResponse;
+import com.example.restate.entity.Mieszkanie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SearchContext {
+
+    private final List<SearchStrategy> strategies;
+
+    public PageResponse<Mieszkanie> executeSearch(SearchStrategy.SearchType type,
+                                                  MieszkanieSearchCriteria criteria,
+                                                  Pageable pageable) {
+
+        SearchStrategy strategy = strategies.stream()
+                .filter(s -> s.supports(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No strategy found for type: " + type));
+
+        // Polimorficzne wywołanie metody search()
+        return strategy.search(criteria, pageable);
+    }
+
+    /**
+     * Automatyczny wybór strategii na podstawie kryteriów
+     */
+    public PageResponse<Mieszkanie> executeAutoSearch(MieszkanieSearchCriteria criteria,
+                                                      Pageable pageable) {
+        SearchStrategy.SearchType type = determineSearchType(criteria);
+        return executeSearch(type, criteria, pageable);
+    }
+
+    private SearchStrategy.SearchType determineSearchType(MieszkanieSearchCriteria criteria) {
+        // Tylko lokalizacja
+        if (criteria.getCity() != null || criteria.getVoivodeship() != null
+                || criteria.getDistrict() != null) {
+            return SearchStrategy.SearchType.BY_LOCATION;
+        }
+
+        // Proste wyszukiwanie
+        if (criteria.getDeveloper() != null || criteria.getInvestment() != null) {
+            return SearchStrategy.SearchType.SIMPLE;
+        }
+
+        // Zaawansowane wyszukiwanie
+        return SearchStrategy.SearchType.ADVANCED;
+    }
+}

--- a/src/main/java/com/example/restate/service/search/SearchStrategy.java
+++ b/src/main/java/com/example/restate/service/search/SearchStrategy.java
@@ -1,0 +1,20 @@
+package com.example.restate.service.search;
+
+import com.example.restate.dto.MieszkanieSearchCriteria;
+import com.example.restate.dto.PageResponse;
+import com.example.restate.entity.Mieszkanie;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Interfejs strategii wyszukiwania
+ */
+public interface SearchStrategy {
+    PageResponse<Mieszkanie> search(MieszkanieSearchCriteria criteria, Pageable pageable);
+    boolean supports(SearchType searchType);
+
+    enum SearchType {
+        SIMPLE,
+        ADVANCED,
+        BY_LOCATION
+    }
+}

--- a/src/main/java/com/example/restate/service/search/SimpleSearchStrategy.java
+++ b/src/main/java/com/example/restate/service/search/SimpleSearchStrategy.java
@@ -1,0 +1,52 @@
+package com.example.restate.service.search;
+
+import com.example.restate.dto.MieszkanieSearchCriteria;
+import com.example.restate.dto.PageResponse;
+import com.example.restate.entity.Mieszkanie;
+import com.example.restate.repository.MieszkanieRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Prosta strategia wyszukiwania - tylko po developerze lub inwestycji
+ */
+@Component
+@RequiredArgsConstructor
+public class SimpleSearchStrategy implements SearchStrategy {
+
+    private final MieszkanieRepository repository;
+
+    @Override
+    public PageResponse<Mieszkanie> search(MieszkanieSearchCriteria criteria, Pageable pageable) {
+        Page<Mieszkanie> page;
+
+        if (criteria.getDeveloper() != null) {
+            page = repository.findByDeveloper(criteria.getDeveloper(), pageable);
+        } else if (criteria.getInvestment() != null) {
+            page = repository.findByInvestment(criteria.getInvestment(), pageable);
+        } else {
+            page = repository.findAll(pageable);
+        }
+
+        return convertToPageResponse(page);
+    }
+
+    @Override
+    public boolean supports(SearchType searchType) {
+        return SearchType.SIMPLE.equals(searchType);
+    }
+
+    private PageResponse<Mieszkanie> convertToPageResponse(Page<Mieszkanie> page) {
+        return PageResponse.<Mieszkanie>builder()
+                .content(page.getContent())
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .first(page.isFirst())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- inject `SearchContext` into `MieszkanieController`
- use `SearchContext` for developer, investment, price-range and area-range queries
- keep automatic and explicit strategy selection in `/search` endpoint
- restore Lombok `@RequiredArgsConstructor` on `MieszkanieController`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684214328ca08332a3e3dbf02b11a758